### PR TITLE
Improvements to Atius PR

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -13,22 +13,19 @@ services:
       MYSQL_ROOT_PASSWORD: local
 
   frontend:
-    build:
-      context: .
-      dockerfile: frontend/Dockerfile
+    build: 
+      context: ./frontend
+      target: dev
     container_name: frontend
     ports:
       - "3000:3000"
-    volumes:
-      - ./frontend:/app
-
-  node:
-    image: arm64v8/node:23
-    container_name: node-cmd
-    working_dir: /app
-    volumes:
-      - ./frontend:/app
+    develop:
+      watch:
+        - path: ./frontend
+          action: sync
+          target: /app
+          ignore:
+            - node_modules/
 
 volumes:
   db:
-  frontend:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,10 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,22 @@
-# This will toggle between separate host platforms
-FROM --platform=$TARGETPLATFORM node:23
+#Build stage
+FROM node:23-alpine AS base
 WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+
+#Dev stage for running VITE in test mode
+FROM base AS dev
 EXPOSE 3000
-CMD ["npm", "run", "dev"]
+CMD ["npm","run","dev"]
+
+#Runs Vite build for deployment
+FROM base AS build
+RUN npm run build
+
+#Production via NGINX
+FROM nginx:1.25.4-alpine-slim AS prod
+COPY --from=build /app/dist /usr/share/nginx/html
+#COPY nginx.conf /etc/nginx/conf.d
+EXPOSE 80
+CMD ["nginx","-g","daemon off;"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
     react(),
   ],
   server: {
+    watch:{
+      usePolling : true
+    },
     port: 3000,
   },
 });


### PR DESCRIPTION
edited dockerfile to run on multi-stage builds - useful to separate prod/dev builds and reduce image size
edited compose to run dev environment in watch mode - prod build not made
edited vite config to enable hot-reloading for development

Dev mode can be run via
`docker compose -f docker-compose-dev.yaml up --watch frontend`